### PR TITLE
Move nu plugins to /usr/libexec/nushell and register them after installation

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -23,12 +23,13 @@ words:
 - pacman
 - gpgkey
 - dearmor
-- gpgcheck
+- libexec
 - nushell
 - Gemfury
 - hustcer
 - rsbuild
 - modeline
+- gpgcheck
 - justfile
 - lefthook
 - linewise

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -90,12 +90,19 @@ contents:
   - src: ./release/nu
     dst: /usr/bin/nu
   - src: ./release/nu_plugin_inc
-    dst: /usr/bin/nu_plugin_inc
+    dst: /usr/libexec/nushell/nu_plugin_inc
   - src: ./release/nu_plugin_query
-    dst: /usr/bin/nu_plugin_query
+    dst: /usr/libexec/nushell/nu_plugin_query
   - src: ./release/nu_plugin_gstat
-    dst: /usr/bin/nu_plugin_gstat
+    dst: /usr/libexec/nushell/nu_plugin_gstat
   - src: ./release/nu_plugin_polars
-    dst: /usr/bin/nu_plugin_polars
+    dst: /usr/libexec/nushell/nu_plugin_polars
   - src: ./release/nu_plugin_formats
-    dst: /usr/bin/nu_plugin_formats
+    dst: /usr/libexec/nushell/nu_plugin_formats
+  - src: ./scripts/post-install.nu
+    dst: /usr/libexec/nushell/post-install.nu
+
+# Scripts to run at specific stages. (overridable)
+scripts:
+  postinstall: ./scripts/post-install.sh
+

--- a/nu/release.nu
+++ b/nu/release.nu
@@ -1,6 +1,6 @@
 #!/usr/bin/env nu
 # Author: hustcer
-# Created: 2025/03/21 19:15:20
+# Created: 2025/02/21 19:15:20
 # Description: Script to release Nushell packages for various Linux distributions.
 # Usage:
 #   docker run -it --rm -v $"(pwd):/work" --platform linux/amd64 ubuntu:latest
@@ -129,6 +129,9 @@ export def 'pkg exists' [
   type: string,   # The package type, e.g. deb & rpm
   arch: string,   # The target architecture, e.g. amd64 & arm64
 ] {
+  if ($env.GEMFURY_TOKEN? | is-empty) {
+    print $'The (ansi r)GEMFURY_TOKEN(ansi reset) is required to check the package existence'; exit 1
+  }
   let versions = fury versions $'($type):nushell' -a nushell --api-token $env.GEMFURY_TOKEN
       | complete | get stdout | lines
       | skip 3 | str join "\n" | detect columns

--- a/scripts/post-install.nu
+++ b/scripts/post-install.nu
@@ -1,0 +1,27 @@
+#!/usr/bin/env nu
+# Author: hustcer
+# Created: 2025/02/25 19:05:20
+# Description: Script to run after installing Nushell.
+
+const PLUGIN_PATH = '/usr/libexec/nushell'
+
+# Register the plugins after installation
+def 'setup-plugins' [] {
+  let plugin_config_dir = $nu.plugin-path | path dirname
+  # This directory must exist before registering plugins
+  if not ($plugin_config_dir | path exists) { mkdir $plugin_config_dir }
+  const NU_PLUGINS = [
+    nu_plugin_inc
+    nu_plugin_query
+    nu_plugin_gstat
+    nu_plugin_polars
+    nu_plugin_formats
+  ]
+  for p in $NU_PLUGINS {
+    plugin add $'($PLUGIN_PATH)/($p)'
+  }
+}
+
+def main [] {
+  setup-plugins
+}

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Author: hustcer
+# Created: 2025/02/25 18:55:20
+
+nu /usr/libexec/nushell/post-install.nu


### PR DESCRIPTION
Move nu plugins to `/usr/libexec/nushell` and register them after installation, fixes #26 