### PR TITLE
Add /usr/bin/nu to /etc/shells after installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
           apk update || true
           # Use --allow-untrusted since the apk package is not signed currently
           apk add --allow-untrusted nushell
+          cat /etc/shells
           nu -c '$nu.current-exe | print; version'
 
   install-rpm:
@@ -66,6 +67,7 @@ jobs:
           gpgkey=https://yum.fury.io/nushell/gpg.key" | tee /etc/yum.repos.d/fury-nushell.repo
           # Install Nushell via dnf
           dnf install -y nushell
+          cat /etc/shells
           # Print nushell version to verify installation
           nu -c '$nu.current-exe | print; ls $nu.default-config-dir | print; version'
 
@@ -83,6 +85,7 @@ jobs:
           echo "deb https://apt.fury.io/nushell/ /" | sudo tee /etc/apt/sources.list.d/fury.list
           sudo apt update
           sudo apt install nushell
+          cat /etc/shells
           nu -c '$nu.current-exe | print; ls $nu.default-config-dir | print; version'
 
   install-on-arch:
@@ -98,6 +101,7 @@ jobs:
             | grep browser_download_url | cut -d '"' -f 4 | grep x86_64.pkg.tar.zst \
             | xargs wget -O nushell.pkg.tar.zst
           pacman -U --noconfirm nushell.pkg.tar.zst
+          cat /etc/shells
           nu -c '$nu.current-exe | print; ls $nu.default-config-dir | print; version'
 
   install-on-debian:
@@ -124,4 +128,5 @@ jobs:
           echo "deb [trusted=yes] https://apt.fury.io/nushell/ /" | tee /etc/apt/sources.list.d/fury.list
           apt update
           apt install nushell
+          cat /etc/shells
           nu -c '$nu.current-exe | print; ls $nu.default-config-dir | print; version'

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -106,11 +106,14 @@ contents:
     dst: /usr/libexec/nushell/nu_plugin_formats
   - src: ./scripts/post-install.nu
     dst: /usr/libexec/nushell/post-install.nu
+  - src: ./scripts/pre-remove.nu
+    dst: /usr/libexec/nushell/pre-remove.nu
   - src: ./release/LICENSE
     dst: /usr/share/licenses/nushell/LICENSE
 
 # Scripts to run at specific stages. (overridable)
 scripts:
+  preremove: ./scripts/pre-remove.sh
   postinstall: ./scripts/post-install.sh
 
 # Custom configuration applied only to the Deb packager.

--- a/scripts/post-install.nu
+++ b/scripts/post-install.nu
@@ -34,7 +34,7 @@ def 'setup-plugins' [] {
 def 'add-shells' [] {
   let shells = open /etc/shells
   if not ($shells =~ $'/usr/bin/nu') {
-    echo '/usr/bin/nu' o>> /etc/shells
+    echo $'/usr/bin/nu(char nl)' o>> /etc/shells
   }
 }
 

--- a/scripts/post-install.nu
+++ b/scripts/post-install.nu
@@ -30,6 +30,15 @@ def 'setup-plugins' [] {
   # plugin list | select name version filename | print
 }
 
+# Add /usr/bin/nu to /etc/shells if it's not already there
+def 'add-shells' [] {
+  let shells = open /etc/shells
+  if not ($shells =~ $'/usr/bin/nu') {
+    echo '/usr/bin/nu' o>> /etc/shells
+  }
+}
+
 def main [] {
   setup-plugins
+  add-shells
 }

--- a/scripts/pre-remove.nu
+++ b/scripts/pre-remove.nu
@@ -5,8 +5,8 @@
 
 # Remove /usr/bin/nu from /etc/shells
 def 'remove-shells' [] {
-  let shells = open /etc/shells | lines
-  $shells
+  open /etc/shells
+    | lines
     | where $it !~ '/usr/bin/nu'
     | str join "\n"
     | save -rf /etc/shells

--- a/scripts/pre-remove.nu
+++ b/scripts/pre-remove.nu
@@ -7,7 +7,7 @@
 def 'remove-shells' [] {
   let shells = open /etc/shells | lines
   $shells
-    | where { $it !~ '/usr/bin/nu' }
+    | where $it !~ '/usr/bin/nu'
     | str join "\n"
     | save -rf /etc/shells
 }

--- a/scripts/pre-remove.nu
+++ b/scripts/pre-remove.nu
@@ -1,0 +1,17 @@
+#!/usr/bin/env nu
+# Author: hustcer
+# Created: 2025/03/10 08:25:20
+# Description: Script to run before removing Nushell.
+
+# Remove /usr/bin/nu from /etc/shells
+def 'remove-shells' [] {
+  let shells = open /etc/shells | lines
+  $shells
+    | where { $it !~ '/usr/bin/nu' }
+    | str join "\n"
+    | save -rf /etc/shells
+}
+
+def main [] {
+  remove-shells
+}

--- a/scripts/pre-remove.sh
+++ b/scripts/pre-remove.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Author: hustcer
+# Created: 2025/03/10 08:35:20
+
+nu /usr/libexec/nushell/pre-remove.nu


### PR DESCRIPTION
Add /usr/bin/nu to /etc/shells after install, and Remove nu from /etc/shells before uninstall, fixes #34, fixes https://github.com/nushell/nushell/issues/15275