### PR TITLE
fix: Ensure config directory exists in post-install and pre-remove

### DIFF
--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -2,4 +2,13 @@
 # Author: hustcer
 # Created: 2025/02/25 18:55:20
 
+if [ -n "${XDG_CONFIG_HOME+x}" ]; then
+	mkdir -p "$XDG_CONFIG_HOME"
+elif [ -n "${HOME+x}" ]; then
+	mkdir -p "$HOME/.config"
+else
+	export XDG_CONFIG_HOME="$PWD/.config"
+	mkdir -p "$XDG_CONFIG_HOME"
+fi
+
 nu /usr/libexec/nushell/post-install.nu

--- a/scripts/pre-remove.sh
+++ b/scripts/pre-remove.sh
@@ -2,4 +2,13 @@
 # Author: hustcer
 # Created: 2025/03/10 08:35:20
 
+if [ -n "${XDG_CONFIG_HOME+x}" ]; then
+	mkdir -p "$XDG_CONFIG_HOME"
+elif [ -n "${HOME+x}" ]; then
+	mkdir -p "$HOME/.config"
+else
+	export XDG_CONFIG_HOME="$PWD/.config"
+	mkdir -p "$XDG_CONFIG_HOME"
+fi
+
 nu /usr/libexec/nushell/pre-remove.nu


### PR DESCRIPTION
This was causing install to fail for rpm-ostree install.