### PR TITLE
fix: Use try-catch to handle winget uninstall errors

### DIFF
--- a/tests/common.nu
+++ b/tests/common.nu
@@ -90,7 +90,12 @@ export def check-version-match [version_expected: string, install_dir = $USER_IN
 }
 
 export def get-latest-tag [] {
-  http get https://api.github.com/repos/nushell/nightly/releases
+  let headers = if ($env.GITHUB_TOKEN? | is-not-empty) {
+    { Authorization: $'Bearer ($env.GITHUB_TOKEN)' }
+  } else {
+    {}
+  }
+  http get -H $headers https://api.github.com/repos/nushell/nightly/releases
     | sort-by -r created_at
     | where tag_name =~ nightly
     | get tag_name?.0?

--- a/tests/test-all.nu
+++ b/tests/test-all.nu
@@ -33,7 +33,7 @@ def main [--msi(-m), --local] {
 }
 
 export def test-msi-per-user-install [] {
-  winget uninstall nushell | complete
+  try { winget uninstall nushell } catch { }
   print $'Using msiexec to test MSI (ansi g)per-user(ansi reset) installation'
   print '-------------------------------------------------------------------'
   msiexec /i $MSI_PKG MSIINSTALLPERUSER=1 /quiet /qn /L*V install.txt
@@ -43,7 +43,7 @@ export def test-msi-per-user-install [] {
 }
 
 export def test-msi-per-machine-install [] {
-  winget uninstall nushell | complete
+  try { winget uninstall nushell } catch { }
   print $'(char nl)Using msiexec to test MSI (ansi g)machine scope(ansi reset) installation'
   print '-------------------------------------------------------------------'
   msiexec /i $MSI_PKG ALLUSERS=1 /L*V install.txt
@@ -53,7 +53,7 @@ export def test-msi-per-machine-install [] {
 }
 
 export def test-winget-per-user-install [--local] {
-  winget uninstall nushell | complete
+  try { winget uninstall nushell } catch { }
   print $'(char nl)Using winget to test MSI (ansi g)user scope(ansi reset) installation'
   print '-------------------------------------------------------------------'
   if $local {
@@ -83,7 +83,7 @@ export def test-winget-per-user-upgrade [--local] {
 }
 
 export def test-winget-per-machine-install [--local] {
-  winget uninstall nushell | complete
+  try { winget uninstall nushell } catch { }
   print $'(char nl)Using winget to test MSI (ansi g)machine scope(ansi reset) installation'
   print '-------------------------------------------------------------------'
   if $local {

--- a/tests/winget-install.nu
+++ b/tests/winget-install.nu
@@ -43,7 +43,12 @@ export def prepare-manifest [] {
 }
 
 def get-download-url [] {
-  http get https://api.github.com/repos/nushell/nightly/releases
+  let headers = if ($env.GITHUB_TOKEN? | is-not-empty) {
+    { Authorization: $'Bearer ($env.GITHUB_TOKEN)' }
+  } else {
+    {}
+  }
+  http get -H $headers https://api.github.com/repos/nushell/nightly/releases
     | sort-by -r created_at
     | where tag_name =~ nightly | get assets.0.browser_download_url
     | where $it =~ 'msi'


### PR DESCRIPTION
The `winget uninstall nushell | complete` pattern fails with exit code -1978335212 (APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND) when nushell is not installed. This change uses try-catch to gracefully handle the error case.